### PR TITLE
Allow Compile for Linux and other Platforms - Update HashSHA256.Build.cs

### DIFF
--- a/Source/HashSHA256/HashSHA256.Build.cs
+++ b/Source/HashSHA256/HashSHA256.Build.cs
@@ -18,7 +18,7 @@ public class HashSHA256 : ModuleRules
 	public HashSHA256(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		
+		PrecompileForTargets = PrecompileTargetsType.Any;
 		PrivateDependencyModuleNames.AddRange(
 			new string[]
 			{


### PR DESCRIPTION
Just something to include in the plugin since I was unable to compile for Linux. I believe this should help with other platforms too (though I am not sure if it works with all platforms),